### PR TITLE
add optional command to run Svg2XmlGui on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Run
 
 `java -classpath lib/mxgraph-core.jar:classes com.mxgraph.svg2xml.Svg2XmlGui`
 
+On Windows 
+`java -cp ./classes;. com.mxgraph.svg2xml.Svg2XmlGui`
+
 
 Quick start quide
 =================

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Run
 `java -classpath lib/mxgraph-core.jar:classes com.mxgraph.svg2xml.Svg2XmlGui`
 
 On Windows 
-`java -cp ./classes;. com.mxgraph.svg2xml.Svg2XmlGui`
+`java -cp classes;lib/mxgraph-core.jar com.mxgraph.svg2xml.Svg2XmlGui`
 
 
 Quick start quide


### PR DESCRIPTION
With this command `java -classpath lib/mxgraph-core.jar:classes com.mxgraph.svg2xml.Svg2XmlGui` got issue:
`Error: Could not find or load main class com.mxgraph.svg2xml.Svg2XmlGui` . Then, I try to use command `java -cp ./classes;. com.mxgraph.svg2xml.Svg2XmlGui`